### PR TITLE
Imp: read network driver and ipam driver from metadata

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -220,15 +220,15 @@ func (h PluginImpl) CreateNetwork(vimInstance interface{}, network catalogue.Bas
 	var driver string
 	if h.Swarm {
 		driver = "overlay"
-	} else if dockerNet.Metadata["driver"] != "" {
-		driver = dockerNet.Metadata["driver"]
+	} else if val, ok := dockerNet.Metadata["driver"]; ok {
+		driver = val
 	} else {
 		driver = "bridge"
 	}
 
-	var ipam *dockerNetwork.IPAM
-	if dockerNet.Metadata["ipam-driver"] != "" {
-		ipam.Driver = dockerNet.Metadata["ipam-driver"]
+	var ipam = &dockerNetwork.IPAM{}
+	if val, ok := dockerNet.Metadata["ipam-driver"]; ok {
+		ipam.Driver = val
 	}
 	if dockerNet.Subnet != "" {
 		ipamConfig := make([]dockerNetwork.IPAMConfig, 1)
@@ -240,9 +240,7 @@ func (h PluginImpl) CreateNetwork(vimInstance interface{}, network catalogue.Bas
 		}
 		inc(ip)
 		ipamConfig[0].Gateway = ip.String()
-		ipam = &dockerNetwork.IPAM{
-			Config: ipamConfig,
-		}
+		ipam.Config = ipamConfig
 	}
 	h.Logger.Debugf("Received DockerNetwork %+v", dockerNet)
 	dockerNet.Name = fmt.Sprintf("%s_%d", dockerNet.Name, 9999-rand.Intn(9000))

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -220,11 +220,16 @@ func (h PluginImpl) CreateNetwork(vimInstance interface{}, network catalogue.Bas
 	var driver string
 	if h.Swarm {
 		driver = "overlay"
+	} else if dockerNet.Metadata["driver"] != "" {
+		driver = dockerNet.Metadata["driver"]
 	} else {
 		driver = "bridge"
 	}
 
 	var ipam *dockerNetwork.IPAM
+	if dockerNet.Metadata["ipam-driver"] != "" {
+		ipam.Driver = dockerNet.Metadata["ipam-driver"]
+	}
 	if dockerNet.Subnet != "" {
 		ipamConfig := make([]dockerNetwork.IPAMConfig, 1)
 		ipamConfig[0].Subnet = dockerNet.Subnet


### PR DESCRIPTION
Checks for set "driver" and "ipam-driver" in network metadata and apllies those for network creation if given.

See https://github.com/openbaton/NFVO/pull/304